### PR TITLE
Increasing the Content Type limit to 1000

### DIFF
--- a/src/contentful-typescript-codegen.ts
+++ b/src/contentful-typescript-codegen.ts
@@ -42,7 +42,7 @@ async function runCodegen(outputFile: string) {
   const getEnvironmentPath = path.resolve(process.cwd(), "./getContentfulEnvironment.js")
   const getEnvironment = require(getEnvironmentPath)
   const environment = await getEnvironment()
-  const contentTypes = await environment.getContentTypes()
+  const contentTypes = await environment.getContentTypes({ limit: 1000 })
   const locales = await environment.getLocales()
   const output = await render(contentTypes.items, locales.items)
 


### PR DESCRIPTION
We were running into an issue of being limited only to 100 entires (default by Contentful) when trying to get Content Types that had more than 100 entries.
This PR increases that limit to the max number Contentful allows (1000)