### PR TITLE
fix(runCodegen): Increase content type API call limit and remove whitespace

### DIFF
--- a/src/contentful-typescript-codegen.ts
+++ b/src/contentful-typescript-codegen.ts
@@ -45,7 +45,6 @@ async function runCodegen(outputFile: string) {
   const contentTypes = await environment.getContentTypes({ limit: 1000 })
   const locales = await environment.getLocales()
   const output = await render(contentTypes.items, locales.items)
-
   const outputPath = path.resolve(process.cwd(), outputFile)
   outputFileSync(outputPath, output)
 }

--- a/src/contentful-typescript-codegen.ts
+++ b/src/contentful-typescript-codegen.ts
@@ -46,6 +46,7 @@ async function runCodegen(outputFile: string) {
   const locales = await environment.getLocales()
   const output = await render(contentTypes.items, locales.items)
   const outputPath = path.resolve(process.cwd(), outputFile)
+
   outputFileSync(outputPath, output)
 }
 


### PR DESCRIPTION
This PR adjusts the amount of whitespace in the main runCodegen function and will serve as the release for the previous PR, [intercom/contentful-typscript-codegen#7](https://github.com/intercom/contentful-typescript-codegen/pull/7) as it wasn't tagged for release and therefore not published.