### PR TITLE
feat(rendering): add a "fields-only" mode for validating responses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: yarn test --ci
-
+          command: yarn test:ci
 
   release:
     <<: *defaults

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "tslint --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "start": "rollup -c rollup.config.ts -w",
     "test": "jest --coverage",
+    "test:ci": "jest --coverage --max-workers=2 --ci",
     "test:prod": "npm run lint && npm run test -- --no-cache",
     "test:watch": "jest --coverage --watch",
     "semantic-release": "semantic-release"

--- a/src/contentful-typescript-codegen.ts
+++ b/src/contentful-typescript-codegen.ts
@@ -11,7 +11,7 @@ const cli = meow(
 	  $ contentful-typescript-codegen --output <file> <options>
 
 	Options
-	  --output,      -o  Where to write to
+    --output,      -o  Where to write to
     --poll,        -p  Continuously refresh types
     --interval N,  -i  The interval in seconds at which to poll (defaults to 15)
     --fields-only      Output a tree that _only_ ensures fields are valid

--- a/src/contentful-typescript-codegen.ts
+++ b/src/contentful-typescript-codegen.ts
@@ -7,10 +7,10 @@ const meow = require("meow")
 
 const cli = meow(
   `
-	Usage
-	  $ contentful-typescript-codegen --output <file> <options>
+  Usage
+    $ contentful-typescript-codegen --output <file> <options>
 
-	Options
+  Options
     --output,      -o  Where to write to
     --poll,        -p  Continuously refresh types
     --interval N,  -i  The interval in seconds at which to poll (defaults to 15)
@@ -19,8 +19,8 @@ const cli = meow(
                        Assets, or Rich Text. This is useful for ensuring raw
                        Contentful responses will be compatible with your code.
 
-	Examples
-	  $ contentful-typescript-codegen -o src/@types/generated/contentful.d.ts
+  Examples
+    $ contentful-typescript-codegen -o src/@types/generated/contentful.d.ts
 `,
   {
     flags: {

--- a/src/renderers/contentful-fields-only/fields/renderArray.ts
+++ b/src/renderers/contentful-fields-only/fields/renderArray.ts
@@ -1,0 +1,28 @@
+import { Field } from "contentful"
+import renderSymbol from "../../contentful/fields/renderSymbol"
+import renderLink from "../../contentful-fields-only/fields/renderLink"
+import renderArrayOf from "../../typescript/renderArrayOf"
+
+export default function renderArray(field: Field): string {
+  if (!field.items) {
+    throw new Error(`Cannot render non-array field ${field.id} as an array`)
+  }
+
+  const fieldWithValidations: Field = {
+    ...field,
+    linkType: field.items.linkType,
+    validations: field.items.validations || [],
+  }
+
+  switch (field.items.type) {
+    case "Symbol": {
+      return renderArrayOf(renderSymbol(fieldWithValidations))
+    }
+
+    case "Link": {
+      return renderArrayOf(renderLink(fieldWithValidations))
+    }
+  }
+
+  return renderArrayOf("unknown")
+}

--- a/src/renderers/contentful-fields-only/fields/renderLink.ts
+++ b/src/renderers/contentful-fields-only/fields/renderLink.ts
@@ -1,0 +1,21 @@
+import { Field } from "contentful"
+import renderContentTypeId from "../../contentful/renderContentTypeId"
+import { renderUnionValues } from "../../typescript/renderUnion"
+
+export default function renderLink(field: Field): string {
+  if (field.linkType === "Asset") {
+    return "any"
+  }
+
+  if (field.linkType === "Entry") {
+    const contentTypeValidation = field.validations.find(validation => !!validation.linkContentType)
+
+    if (contentTypeValidation) {
+      return renderUnionValues(contentTypeValidation.linkContentType!.map(renderContentTypeId))
+    } else {
+      return "unknown"
+    }
+  }
+
+  return "unknown"
+}

--- a/src/renderers/contentful-fields-only/fields/renderRichText.ts
+++ b/src/renderers/contentful-fields-only/fields/renderRichText.ts
@@ -1,0 +1,5 @@
+import { Field } from "contentful"
+
+export default function renderRichText(field: Field): string {
+  return "any"
+}

--- a/src/renderers/contentful-fields-only/renderContentType.ts
+++ b/src/renderers/contentful-fields-only/renderContentType.ts
@@ -1,0 +1,51 @@
+import { ContentType, Field, FieldType } from "contentful"
+
+import renderInterface from "../typescript/renderInterface"
+import renderField from "../contentful/renderField"
+import renderContentTypeId from "../contentful/renderContentTypeId"
+
+import renderArray from "../contentful-fields-only/fields/renderArray"
+import renderLink from "../contentful-fields-only/fields/renderLink"
+import renderRichText from "../contentful-fields-only/fields/renderRichText"
+
+import renderBoolean from "../contentful/fields/renderBoolean"
+import renderLocation from "../contentful/fields/renderLocation"
+import renderNumber from "../contentful/fields/renderNumber"
+import renderObject from "../contentful/fields/renderObject"
+import renderSymbol from "../contentful/fields/renderSymbol"
+
+export default function renderContentType(contentType: ContentType): string {
+  const name = renderContentTypeId(contentType.sys.id)
+  const fields = renderContentTypeFields(contentType.fields)
+
+  return renderInterface({
+    name,
+    fields: `
+      fields: { ${fields} };
+      [otherKeys: string]: any
+    `,
+  })
+}
+
+function renderContentTypeFields(fields: Field[]): string {
+  return fields
+    .filter(field => !field.omitted)
+    .map<string>(field => {
+      const functionMap: Record<FieldType, (field: Field) => string> = {
+        Array: renderArray,
+        Boolean: renderBoolean,
+        Date: renderSymbol,
+        Integer: renderNumber,
+        Link: renderLink,
+        Location: renderLocation,
+        Number: renderNumber,
+        Object: renderObject,
+        RichText: renderRichText,
+        Symbol: renderSymbol,
+        Text: renderSymbol,
+      }
+
+      return renderField(field, functionMap[field.type](field))
+    })
+    .join("\n\n")
+}

--- a/src/renderers/contentful-fields-only/renderContentType.ts
+++ b/src/renderers/contentful-fields-only/renderContentType.ts
@@ -22,7 +22,7 @@ export default function renderContentType(contentType: ContentType): string {
     name,
     fields: `
       fields: { ${fields} };
-      [otherKeys: string]: any
+      [otherKeys: string]: any;
     `,
   })
 }

--- a/src/renderers/contentful/renderContentType.ts
+++ b/src/renderers/contentful/renderContentType.ts
@@ -13,13 +13,25 @@ import renderObject from "./fields/renderObject"
 import renderRichText from "./fields/renderRichText"
 import renderSymbol from "./fields/renderSymbol"
 
-export default function renderContentType(contentType: ContentType) {
-  return renderInterface(
-    renderContentTypeId(contentType.sys.id),
-    renderContentTypeFields(contentType.fields),
-    contentType.description,
-    renderSys(contentType.sys),
-  )
+export default function renderContentType(contentType: ContentType): string {
+  const name = renderContentTypeId(contentType.sys.id)
+  const fields = renderContentTypeFields(contentType.fields)
+  const sys = renderSys(contentType.sys)
+
+  return `
+    ${renderInterface({ name: `${name}Fields`, fields })}
+
+    ${descriptionComment(contentType.description)}
+    ${renderInterface({ name, extension: `Entry<${name}Fields>`, fields: sys })}
+  `
+}
+
+function descriptionComment(description: string | undefined) {
+  if (description) {
+    return `/** ${description} */`
+  }
+
+  return ""
 }
 
 function renderContentTypeFields(fields: Field[]): string {

--- a/src/renderers/renderFieldsOnly.ts
+++ b/src/renderers/renderFieldsOnly.ts
@@ -1,0 +1,17 @@
+import { ContentType } from "contentful"
+
+import { format } from "prettier"
+
+import renderContentType from "./contentful-fields-only/renderContentType"
+
+export default async function renderFieldsOnly(contentTypes: ContentType[]) {
+  const sortedContentTypes = contentTypes.sort((a, b) => a.sys.id.localeCompare(b.sys.id))
+
+  const source = renderAllContentTypes(sortedContentTypes)
+
+  return format(source, { parser: "typescript" })
+}
+
+function renderAllContentTypes(contentTypes: ContentType[]): string {
+  return contentTypes.map(contentType => renderContentType(contentType)).join("\n\n")
+}

--- a/src/renderers/typescript/renderInterface.ts
+++ b/src/renderers/typescript/renderInterface.ts
@@ -1,25 +1,18 @@
-export default function renderInterface(
-  name: string,
-  fields: string,
-  description?: string,
-  contents?: string,
-): string {
+export default function renderInterface({
+  name,
+  extension,
+  fields,
+  description,
+}: {
+  name: string
+  extension?: string
+  fields: string
+  description?: string
+}) {
   return `
-    export interface ${name}Fields {
+    ${description ? `/** ${description} */` : ""}
+    export interface ${name} ${extension ? `extends ${extension}` : ""} {
       ${fields}
-    };
-
-    ${descriptionComment(description)}
-    export interface ${name} extends Entry<${name}Fields> {
-      ${contents || ""}
-    };
+    }
   `
-}
-
-function descriptionComment(description: string | undefined) {
-  if (description) {
-    return `/** ${description} */`
-  }
-
-  return ""
 }

--- a/test/renderers/contentful-fields-only/fields/renderArray.test.ts
+++ b/test/renderers/contentful-fields-only/fields/renderArray.test.ts
@@ -1,0 +1,69 @@
+import renderArray from "../../../../src/renderers/contentful-fields-only/fields/renderArray"
+import { Field } from "contentful"
+
+describe("renderArray()", () => {
+  it("renders an array of symbols", () => {
+    const arrayOfSymbols: Field = {
+      type: "Array",
+      id: "fieldId",
+      name: "Field Name",
+      validations: [],
+      omitted: false,
+      required: true,
+      disabled: false,
+      linkType: undefined,
+      localized: false,
+      items: {
+        type: "Symbol",
+        validations: [],
+      },
+    }
+
+    expect(renderArray(arrayOfSymbols)).toMatchInlineSnapshot(`"(string)[]"`)
+  })
+
+  it("renders an array of symbols with validations", () => {
+    const arrayOfValidatedSymbols: Field = {
+      type: "Array",
+      id: "fieldId",
+      name: "Field Name",
+      validations: [],
+      omitted: false,
+      required: true,
+      disabled: false,
+      linkType: undefined,
+      localized: false,
+      items: {
+        type: "Symbol",
+        validations: [{ in: ["one", "of", "these"] }],
+      },
+    }
+
+    expect(renderArray(arrayOfValidatedSymbols)).toMatchInlineSnapshot(
+      `"('one' | 'of' | 'these')[]"`,
+    )
+  })
+
+  it("renders an array of links of a particular type", () => {
+    const arrayOfValidatedSymbols: Field = {
+      type: "Array",
+      id: "fieldId",
+      name: "Field Name",
+      validations: [],
+      omitted: false,
+      required: true,
+      disabled: false,
+      linkType: undefined,
+      localized: false,
+      items: {
+        type: "Link",
+        linkType: "Entry",
+        validations: [{ linkContentType: ["contentType1", "contentType2"] }],
+      },
+    }
+
+    expect(renderArray(arrayOfValidatedSymbols)).toMatchInlineSnapshot(
+      `"(IContentType1 | IContentType2)[]"`,
+    )
+  })
+})

--- a/test/renderers/contentful-fields-only/fields/renderLink.test.ts
+++ b/test/renderers/contentful-fields-only/fields/renderLink.test.ts
@@ -1,0 +1,68 @@
+import renderLink from "../../../../src/renderers/contentful-fields-only/fields/renderLink"
+import { Field } from "contentful"
+
+describe("renderLink()", () => {
+  it("renders a simple entry link", () => {
+    const simpleEntryLink: Field = {
+      id: "validatedEntryLink",
+      name: "Entry Link",
+      type: "Link",
+      localized: false,
+      required: false,
+      validations: [],
+      disabled: false,
+      omitted: false,
+      linkType: "Entry",
+    }
+
+    expect(renderLink(simpleEntryLink)).toMatchInlineSnapshot(`"unknown"`)
+  })
+
+  it("renders a link with validations", () => {
+    const validatedEntryLink: Field = {
+      id: "validatedEntryLink",
+      name: "Entry Link",
+      type: "Link",
+      localized: false,
+      required: false,
+      validations: [{ linkContentType: ["linkToOtherThing"] }],
+      disabled: false,
+      omitted: false,
+      linkType: "Entry",
+    }
+
+    expect(renderLink(validatedEntryLink)).toMatchInlineSnapshot(`"ILinkToOtherThing"`)
+  })
+
+  it("renders an asset link", () => {
+    const assetLink: Field = {
+      id: "assetLink",
+      name: "Asset Link",
+      type: "Link",
+      linkType: "Asset",
+      localized: false,
+      required: true,
+      validations: [],
+      disabled: false,
+      omitted: false,
+    }
+
+    expect(renderLink(assetLink)).toMatchInlineSnapshot(`"any"`)
+  })
+
+  it("handles mysteries", () => {
+    const mysteryLink: Field = {
+      id: "mysteryLink",
+      name: "Mystery Link",
+      type: "Link",
+      linkType: "Idk",
+      localized: false,
+      required: true,
+      validations: [],
+      disabled: false,
+      omitted: false,
+    }
+
+    expect(renderLink(mysteryLink)).toMatchInlineSnapshot(`"unknown"`)
+  })
+})

--- a/test/renderers/contentful-fields-only/fields/renderRichText.test.ts
+++ b/test/renderers/contentful-fields-only/fields/renderRichText.test.ts
@@ -1,0 +1,20 @@
+import renderRichText from "../../../../src/renderers/contentful-fields-only/fields/renderRichText"
+import { Field } from "contentful"
+
+describe("renderRichText()", () => {
+  const simpleRichText: Field = {
+    type: "Object",
+    id: "fieldId",
+    name: "Field Name",
+    validations: [],
+    omitted: false,
+    required: true,
+    disabled: false,
+    linkType: undefined,
+    localized: false,
+  }
+
+  it("works", () => {
+    expect(renderRichText(simpleRichText).trim()).toMatchInlineSnapshot(`"any"`)
+  })
+})

--- a/test/renderers/contentful-fields-only/renderContentType.test.ts
+++ b/test/renderers/contentful-fields-only/renderContentType.test.ts
@@ -1,0 +1,60 @@
+import renderContentType from "../../../src/renderers/contentful-fields-only/renderContentType"
+import { ContentType, Sys } from "contentful"
+import format from "../../support/format"
+
+describe("renderContentType()", () => {
+  const contentType: ContentType = {
+    sys: {
+      id: "myContentType",
+    } as Sys,
+    fields: [
+      {
+        id: "symbolField",
+        name: "Symbol Field™",
+        required: false,
+        validations: [],
+        disabled: false,
+        omitted: false,
+        localized: false,
+        type: "Symbol",
+      },
+      {
+        id: "arrayField",
+        name: "Array field",
+        required: true,
+        validations: [{}],
+        items: {
+          type: "Symbol",
+          validations: [
+            {
+              in: ["one", "of", "the", "above"],
+            },
+          ],
+        },
+        disabled: false,
+        omitted: false,
+        localized: false,
+        type: "Array",
+      },
+    ],
+    description: "",
+    displayField: "",
+    name: "",
+    toPlainObject: () => ({} as ContentType),
+  }
+
+  it("works with miscellaneous field types", () => {
+    expect(format(renderContentType(contentType))).toMatchInlineSnapshot(`
+      "export interface IMyContentType {
+        fields: {
+          /** Symbol Field™ */
+          symbolField?: string | undefined,
+
+          /** Array field */
+          arrayField: (\\"one\\" | \\"of\\" | \\"the\\" | \\"above\\")[]
+        };
+        [otherKeys: string]: any;
+      }"
+    `)
+  })
+})

--- a/test/renderers/contentful/renderContentType.test.ts
+++ b/test/renderers/contentful/renderContentType.test.ts
@@ -2,7 +2,7 @@ import renderContentType from "../../../src/renderers/contentful/renderContentTy
 import { ContentType, Sys } from "contentful"
 import format from "../../support/format"
 
-describe("renderSymbol()", () => {
+describe("renderContentType()", () => {
   const contentType: ContentType = {
     sys: {
       id: "myContentType",
@@ -43,15 +43,51 @@ describe("renderSymbol()", () => {
     toPlainObject: () => ({} as ContentType),
   }
 
+  const contentTypeWithDescription: ContentType = {
+    sys: {
+      id: "myContentType",
+    } as Sys,
+    fields: [],
+    description: "This is a description",
+    displayField: "",
+    name: "",
+    toPlainObject: () => ({} as ContentType),
+  }
+
   it("works with miscellaneous field types", () => {
     expect(format(renderContentType(contentType))).toMatchInlineSnapshot(`
-      "export interface IMyContentTypeFields {
-        /** Symbol Field™ */
-        symbolField?: string | undefined;
+            "export interface IMyContentTypeFields {
+              /** Symbol Field™ */
+              symbolField?: string | undefined;
 
-        /** Array field */
-        arrayField: (\\"one\\" | \\"of\\" | \\"the\\" | \\"above\\")[];
-      }
+              /** Array field */
+              arrayField: (\\"one\\" | \\"of\\" | \\"the\\" | \\"above\\")[];
+            }
+
+            export interface IMyContentType extends Entry<IMyContentTypeFields> {
+              sys: {
+                id: string,
+                type: string,
+                createdAt: string,
+                updatedAt: string,
+                locale: string,
+                contentType: {
+                  sys: {
+                    id: \\"myContentType\\",
+                    linkType: \\"ContentType\\",
+                    type: \\"Link\\"
+                  }
+                }
+              };
+            }"
+        `)
+  })
+
+  it("supports descriptions", () => {
+    expect(format(renderContentType(contentTypeWithDescription))).toMatchInlineSnapshot(`
+      "export interface IMyContentTypeFields {}
+
+      /** This is a description */
 
       export interface IMyContentType extends Entry<IMyContentTypeFields> {
         sys: {

--- a/test/renderers/renderFieldsOnly.test.ts
+++ b/test/renderers/renderFieldsOnly.test.ts
@@ -1,0 +1,49 @@
+import renderFieldsOnly from "../../src/renderers/renderFieldsOnly"
+import { ContentType, Sys } from "contentful"
+
+describe("renderFieldsOnly()", () => {
+  it("renders given a content type", async () => {
+    const contentTypes: ContentType[] = [
+      {
+        sys: {
+          id: "myContentType",
+        } as Sys,
+        fields: [
+          {
+            id: "arrayField",
+            name: "Array field",
+            required: true,
+            validations: [{}],
+            items: {
+              type: "Symbol",
+              validations: [
+                {
+                  in: ["one", "of", "the", "above"],
+                },
+              ],
+            },
+            disabled: false,
+            omitted: false,
+            localized: false,
+            type: "Array",
+          },
+        ],
+        description: "",
+        displayField: "",
+        name: "",
+        toPlainObject: () => ({} as ContentType),
+      },
+    ]
+
+    expect(await renderFieldsOnly(contentTypes)).toMatchInlineSnapshot(`
+      "export interface IMyContentType {
+        fields: {
+          /** Array field */
+          arrayField: (\\"one\\" | \\"of\\" | \\"the\\" | \\"above\\")[];
+        };
+        [otherKeys: string]: any;
+      }
+      "
+    `)
+  })
+})

--- a/test/renderers/typescript/renderInterface.test.ts
+++ b/test/renderers/typescript/renderInterface.test.ts
@@ -3,24 +3,28 @@ import format from "../../support/format"
 
 describe("renderInterface()", () => {
   it("works", () => {
-    expect(format(renderInterface("IFoo", "field: string"))).toMatchInlineSnapshot(`
-"export interface IFooFields {
-  field: string;
-}
-
-export interface IFoo extends Entry<IFooFields> {}"
-`)
+    expect(format(renderInterface({ name: "IFoo", fields: "field: string" })))
+      .toMatchInlineSnapshot(`
+      "export interface IFoo {
+        field: string;
+      }"
+    `)
   })
 
   it("adds comments to interfaces", () => {
-    expect(format(renderInterface("IFoo", "field: string", "Example interface")))
-      .toMatchInlineSnapshot(`
-"export interface IFooFields {
-  field: string;
-}
-
-/** Example interface */
-export interface IFoo extends Entry<IFooFields> {}"
-`)
+    expect(
+      format(
+        renderInterface({
+          name: "IFoo",
+          fields: "field: string",
+          description: "Example interface",
+        }),
+      ),
+    ).toMatchInlineSnapshot(`
+      "/** Example interface */
+      export interface IFoo {
+        field: string;
+      }"
+    `)
   })
 })


### PR DESCRIPTION
At Intercom, we have a need to validate Contentful responses to ensure they match the schema constructed by the codegen. This will prevent our marketing site from building if Contentful content is unexpectedly unpublished, the validations are messed up, or (hopefully) any other discrepancy.

This flag is intended to support the use case where you want to ensure that all of the fields in the Contentful response are well-formed, but don't want to validate auxilliary things like Sys, Assets, etc.

This mode outputs a super minimal codegen file, like this:

```ts
export interface IActivePeopleRow {
  fields: {
    /** [Entry Description] */
    entryDescription: string;

    /** Bracket */
    bracket: string;

    // ...
  };
  [otherKeys: string]: any;
}

export interface IBasicHeader {
  fields: {
    /** Description */
    description: string;

    /** Logo Text */
    logoText?: string | undefined;

    // ...
  };
  [otherKeys: string]: any;
}

// ...
```