### PR TITLE
fix(cli): return a non-zero exit code on failure

### DIFF
--- a/src/contentful-typescript-codegen.ts
+++ b/src/contentful-typescript-codegen.ts
@@ -67,6 +67,7 @@ async function runCodegen(outputFile: string) {
 
 runCodegen(cli.flags.output).catch(error => {
   console.error(error)
+  process.exit(1)
 })
 
 if (cli.flags.poll) {


### PR DESCRIPTION
Previously, this script would silently fail when an error was encountered. This breaks builds. Now,
it will return an exit code of 1 when an error is encountered.

BREAKING CHANGE: This may lead builds to break that previously succeeded. This would mean that there was previously an uncaught error in your setup. Well-configured, healthy builds should remain unaffected.