### PR TITLE
Render interfaces without fields attribute, to enable more usecases for types

### DIFF
--- a/src/contentful-typescript-codegen.ts
+++ b/src/contentful-typescript-codegen.ts
@@ -2,6 +2,7 @@ import render from "./renderers/render"
 import renderFieldsOnly from "./renderers/renderFieldsOnly"
 import path from "path"
 import { outputFileSync } from "fs-extra"
+import renderPropsOnly from "./renderers/renderPropsOnly"
 
 const meow = require("meow")
 
@@ -18,6 +19,10 @@ const cli = meow(
                        and present, and does not provide types for Sys,
                        Assets, or Rich Text. This is useful for ensuring raw
                        Contentful responses will be compatible with your code.
+    --props-only       Output only the interfaces for the plain object
+                       properties of your Contentful models. This is useful when
+                       adding type information to GraphQL responses, e.g. when
+                       using Contentful with Gatsby.
 
   Examples
     $ contentful-typescript-codegen -o src/@types/generated/contentful.d.ts
@@ -36,6 +41,10 @@ const cli = meow(
       poll: {
         type: "boolean",
         alias: "p",
+        required: false,
+      },
+      propsOnly: {
+        type: "boolean",
         required: false,
       },
       interval: {
@@ -58,6 +67,8 @@ async function runCodegen(outputFile: string) {
   let output
   if (cli.flags.fieldsOnly) {
     output = await renderFieldsOnly(contentTypes.items)
+  } else if (cli.flags.propsOnly) {
+    output = await renderPropsOnly(contentTypes.items)
   } else {
     output = await render(contentTypes.items, locales.items)
   }

--- a/src/renderers/contentful-fields-only/renderContentType.ts
+++ b/src/renderers/contentful-fields-only/renderContentType.ts
@@ -27,7 +27,7 @@ export default function renderContentType(contentType: ContentType): string {
   })
 }
 
-function renderContentTypeFields(fields: Field[]): string {
+export function renderContentTypeFields(fields: Field[]): string {
   return fields
     .filter(field => !field.omitted)
     .map<string>(field => {

--- a/src/renderers/contentful-props-only/renderContentType.ts
+++ b/src/renderers/contentful-props-only/renderContentType.ts
@@ -1,0 +1,14 @@
+import { ContentType } from "contentful"
+import renderContentTypeId from "../contentful/renderContentTypeId"
+import { renderContentTypeFields } from "../contentful-fields-only/renderContentType"
+import renderInterface from "../typescript/renderInterface"
+
+export default function renderContentType(contentType: ContentType): string {
+  const name = renderContentTypeId(contentType.sys.id)
+  const fields = renderContentTypeFields(contentType.fields)
+
+  return renderInterface({
+    name,
+    fields,
+  })
+}

--- a/src/renderers/renderPropsOnly.ts
+++ b/src/renderers/renderPropsOnly.ts
@@ -1,0 +1,17 @@
+import { ContentType } from "contentful"
+
+import { format } from "prettier"
+
+import renderContentType from "./contentful-props-only/renderContentType"
+
+export default async function renderPropsOnly(contentTypes: ContentType[]) {
+  const sortedContentTypes = contentTypes.sort()
+
+  const source = renderAllContentTypes(sortedContentTypes)
+
+  return format(source, { parser: "typescript" })
+}
+
+function renderAllContentTypes(contentTypes: ContentType[]): string {
+  return contentTypes.map(contentType => renderContentType(contentType)).join("\n\n")
+}

--- a/test/renderers/contentful-props-only/renderContentType.test.ts
+++ b/test/renderers/contentful-props-only/renderContentType.test.ts
@@ -1,0 +1,57 @@
+import renderContentType from "../../../src/renderers/contentful-props-only/renderContentType"
+import { ContentType, Sys } from "contentful"
+import format from "../../support/format"
+
+describe("renderContentType()", () => {
+  const contentType: ContentType = {
+    sys: {
+      id: "myContentType",
+    } as Sys,
+    fields: [
+      {
+        id: "symbolField",
+        name: "Symbol Field™",
+        required: false,
+        validations: [],
+        disabled: false,
+        omitted: false,
+        localized: false,
+        type: "Symbol",
+      },
+      {
+        id: "arrayField",
+        name: "Array field",
+        required: true,
+        validations: [{}],
+        items: {
+          type: "Symbol",
+          validations: [
+            {
+              in: ["one", "of", "the", "above"],
+            },
+          ],
+        },
+        disabled: false,
+        omitted: false,
+        localized: false,
+        type: "Array",
+      },
+    ],
+    description: "",
+    displayField: "",
+    name: "",
+    toPlainObject: () => ({} as ContentType),
+  }
+
+  it("works with miscellaneous field types", () => {
+    expect(format(renderContentType(contentType))).toMatchInlineSnapshot(`
+      "export interface IMyContentType {
+        /** Symbol Field™ */
+        symbolField?: string | undefined;
+
+        /** Array field */
+        arrayField: (\\"one\\" | \\"of\\" | \\"the\\" | \\"above\\")[];
+      }"
+    `)
+  })
+})

--- a/test/renderers/renderPropsOnly.test.ts
+++ b/test/renderers/renderPropsOnly.test.ts
@@ -1,0 +1,46 @@
+import renderPropsOnly from "../../src/renderers/renderPropsOnly"
+import { ContentType, Sys } from "contentful"
+
+describe("renderPropsOnly()", () => {
+  it("renders given a content type", async () => {
+    const contentTypes: ContentType[] = [
+      {
+        sys: {
+          id: "myContentType",
+        } as Sys,
+        fields: [
+          {
+            id: "arrayField",
+            name: "Array field",
+            required: true,
+            validations: [{}],
+            items: {
+              type: "Symbol",
+              validations: [
+                {
+                  in: ["one", "of", "the", "above"],
+                },
+              ],
+            },
+            disabled: false,
+            omitted: false,
+            localized: false,
+            type: "Array",
+          },
+        ],
+        description: "",
+        displayField: "",
+        name: "",
+        toPlainObject: () => ({} as ContentType),
+      },
+    ]
+
+    expect(await renderPropsOnly(contentTypes)).toMatchInlineSnapshot(`
+      "export interface IMyContentType {
+        /** Array field */
+        arrayField: (\\"one\\" | \\"of\\" | \\"the\\" | \\"above\\")[];
+      }
+      "
+    `)
+  })
+})


### PR DESCRIPTION
In order to allow these interfaces to add typing information to GraphQL queries against Contentful, render them without the top-level field attribute and only render their props.

re #17

I'm not sure if this is how you'd like to approach supporting a use case like this, let me know if there's anything I can rework to get this merged! :)