### PR TITLE
Allow any version of prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "meow": "^5.0.0"
   },
   "peerDependencies": {
-    "prettier": "1.x"
+    "prettier": ">= 1"
   },
   "devDependencies": {
     "@contentful/rich-text-types": "^13.4.0",


### PR DESCRIPTION
Just trying to squelch this warning:

`warning " > contentful-typescript-codegen@3.2.1" has unmet peer dependency "prettier@1.x".`