### PR TITLE
Add a REPO_OWNER file

### DIFF
--- a/REPO_OWNER
+++ b/REPO_OWNER
@@ -1,0 +1,1 @@
+team-acquisition


### PR DESCRIPTION
Intercom uses this file to route dependabot issues to the correct internal team.