### PR TITLE
Use unknown instead of any for better type safety

### DIFF
--- a/src/renderers/contentful-fields-only/fields/renderLink.ts
+++ b/src/renderers/contentful-fields-only/fields/renderLink.ts
@@ -4,7 +4,7 @@ import { renderUnionValues } from "../../typescript/renderUnion"
 
 export default function renderLink(field: Field): string {
   if (field.linkType === "Asset") {
-    return "any"
+    return "unknown"
   }
 
   if (field.linkType === "Entry") {

--- a/src/renderers/contentful-fields-only/fields/renderRichText.ts
+++ b/src/renderers/contentful-fields-only/fields/renderRichText.ts
@@ -1,5 +1,5 @@
 import { Field } from "contentful"
 
 export default function renderRichText(field: Field): string {
-  return "any"
+  return "unknown"
 }

--- a/src/renderers/contentful-fields-only/renderContentType.ts
+++ b/src/renderers/contentful-fields-only/renderContentType.ts
@@ -22,7 +22,7 @@ export default function renderContentType(contentType: ContentType): string {
     name,
     fields: `
       fields: { ${fields} };
-      [otherKeys: string]: any;
+      [otherKeys: string]: unknown;
     `,
   })
 }

--- a/src/renderers/contentful/fields/renderObject.ts
+++ b/src/renderers/contentful/fields/renderObject.ts
@@ -1,5 +1,5 @@
 import { Field } from "contentful"
 
 export default function renderObject(field: Field): string {
-  return "Record<string, any>"
+  return "Record<string, unknown>"
 }

--- a/test/renderers/contentful-fields-only/fields/renderLink.test.ts
+++ b/test/renderers/contentful-fields-only/fields/renderLink.test.ts
@@ -47,7 +47,7 @@ describe("renderLink()", () => {
       omitted: false,
     }
 
-    expect(renderLink(assetLink)).toMatchInlineSnapshot(`"any"`)
+    expect(renderLink(assetLink)).toMatchInlineSnapshot(`"unknown"`)
   })
 
   it("handles mysteries", () => {

--- a/test/renderers/contentful-fields-only/fields/renderRichText.test.ts
+++ b/test/renderers/contentful-fields-only/fields/renderRichText.test.ts
@@ -15,6 +15,6 @@ describe("renderRichText()", () => {
   }
 
   it("works", () => {
-    expect(renderRichText(simpleRichText).trim()).toMatchInlineSnapshot(`"any"`)
+    expect(renderRichText(simpleRichText).trim()).toMatchInlineSnapshot(`"unknown"`)
   })
 })

--- a/test/renderers/contentful-fields-only/renderContentType.test.ts
+++ b/test/renderers/contentful-fields-only/renderContentType.test.ts
@@ -53,7 +53,7 @@ describe("renderContentType()", () => {
           /** Array field */
           arrayField: (\\"one\\" | \\"of\\" | \\"the\\" | \\"above\\")[]
         };
-        [otherKeys: string]: any;
+        [otherKeys: string]: unknown;
       }"
     `)
   })

--- a/test/renderers/contentful/fields/renderObject.test.ts
+++ b/test/renderers/contentful/fields/renderObject.test.ts
@@ -15,6 +15,6 @@ describe("renderObject()", () => {
   }
 
   it("works", () => {
-    expect(renderObject(simpleObject).trim()).toMatchInlineSnapshot(`"Record<string, any>"`)
+    expect(renderObject(simpleObject).trim()).toMatchInlineSnapshot(`"Record<string, unknown>"`)
   })
 })

--- a/test/renderers/renderFieldsOnly.test.ts
+++ b/test/renderers/renderFieldsOnly.test.ts
@@ -41,7 +41,7 @@ describe("renderFieldsOnly()", () => {
                 /** Array field */
                 arrayField: (\\"one\\" | \\"of\\" | \\"the\\" | \\"above\\")[]
               }
-              [otherKeys: string]: any
+              [otherKeys: string]: unknown
             }
             "
         `)
@@ -55,7 +55,7 @@ describe("renderFieldsOnly()", () => {
             /** Array field */
             arrayField: (\\"one\\" | \\"of\\" | \\"the\\" | \\"above\\")[]
           }
-          [otherKeys: string]: any
+          [otherKeys: string]: unknown
         }
       }
 


### PR DESCRIPTION
To start this PR off, thank you for this project - I think it's a great tool to improve code quality and developer experience in Contentful/Typescript projects.

Now, I noticed that the generator sometimes returns `any` as a type. While it works, generally it's advised to use the `unknown` type in situations like this one, where more detailed typing information is unavailable. It's a minor change, but it does mean that the generated types provide more safety.

I'm curious to hear your thoughts about this and hereby provide a PR with the change.