### PR TITLE
update: Check if validations field is an array

### DIFF
--- a/src/renderers/contentful-fields-only/fields/renderLink.ts
+++ b/src/renderers/contentful-fields-only/fields/renderLink.ts
@@ -8,7 +8,7 @@ export default function renderLink(field: Field): string {
   }
 
   if (field.linkType === "Entry") {
-    const contentTypeValidation = field.validations.find(validation => !!validation.linkContentType)
+    const contentTypeValidation = Array.isArray(field.validations) && field.validations.find(validation => !!validation.linkContentType)
 
     if (contentTypeValidation) {
       return renderUnionValues(contentTypeValidation.linkContentType!.map(renderContentTypeId))

--- a/src/renderers/contentful/fields/renderLink.ts
+++ b/src/renderers/contentful/fields/renderLink.ts
@@ -8,7 +8,7 @@ export default function renderLink(field: Field): string {
   }
 
   if (field.linkType === "Entry") {
-    const contentTypeValidation = field.validations.find(validation => !!validation.linkContentType)
+    const contentTypeValidation = Array.isArray(field.validations) && field.validations.find(validation => !!validation.linkContentType)
 
     if (contentTypeValidation) {
       return renderUnionValues(contentTypeValidation.linkContentType!.map(renderContentTypeId))

--- a/src/renderers/contentful/fields/renderSymbol.ts
+++ b/src/renderers/contentful/fields/renderSymbol.ts
@@ -3,7 +3,7 @@ import { Field } from "contentful"
 import { renderUnionValues } from "../../typescript/renderUnion"
 
 export default function renderSymbol(field: Field) {
-  const inValidation = field.validations.find(validation => !!validation.in)
+  const inValidation = Array.isArray(field.validations) && field.validations.find(validation => !!validation.in)
 
   if (inValidation) {
     return renderUnionValues(inValidation.in!.map(value => `'${value}'`))


### PR DESCRIPTION
Previously, this script was erroring out when used with my contentful setup because the field object did not include the validations field in the contentful response. The script was calling `.find` on undefined so this ensures that we check that the validations field is an array before calling `.find`