### PR TITLE
fix(bugfixes): escape single quotes and upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Generate typings from your Contentful environment.
 - Locales (and your default locale) become string types.
 - Assets and Rich Text link to Contentful's types.
 
-At Intercom, we use this in our [marketing site] to increase developer confidence and productivity,
+At Intercom, we use this in our [website] to increase developer confidence and productivity,
 ensure that breaking changes to our Content Types don't cause an outage, and because it's neat.
 
-[marketing site]: https://www.intercom.com
+[website]: https://www.intercom.com
 
 ## Usage
 


### PR DESCRIPTION
I wasn't familiar with `semantic-release`. The last bugfix (https://github.com/intercom/contentful-typescript-codegen/pull/98) didn't trigger a release because the commit name didn't follow the required [commit message format](https://github.com/semantic-release/semantic-release#commit-message-format).

With this commit message I'm forcing a new minor release (3.2.3)