### PR TITLE
feat(render): add 'IEntry' type containing all possible of entries

### DIFF
--- a/src/renderers/render.ts
+++ b/src/renderers/render.ts
@@ -9,6 +9,7 @@ import renderAllLocales from "./contentful/renderAllLocales"
 import renderDefaultLocale from "./contentful/renderDefaultLocale"
 import renderNamespace from "./contentful/renderNamespace"
 import renderLocalizedTypes from "./contentful/renderLocalizedTypes"
+import renderContentTypeId from "./contentful/renderContentTypeId"
 
 interface Options {
   localization?: boolean
@@ -26,6 +27,7 @@ export default async function render(
   const typingsSource = [
     renderAllContentTypes(sortedContentTypes, localization),
     renderAllContentTypeIds(sortedContentTypes),
+    renderEntryType(sortedContentTypes),
     renderAllLocales(sortedLocales),
     renderDefaultLocale(sortedLocales),
     renderLocalizedTypes(localization),
@@ -48,5 +50,12 @@ function renderAllContentTypeIds(contentTypes: ContentType[]): string {
   return renderUnion(
     "CONTENT_TYPE",
     contentTypes.map(contentType => `'${contentType.sys.id}'`),
+  )
+}
+
+function renderEntryType(contentTypes: ContentType[]) {
+  return renderUnion(
+    "IEntry",
+    contentTypes.map(contentType => renderContentTypeId(contentType.sys.id)),
   )
 }

--- a/test/renderers/render.test.ts
+++ b/test/renderers/render.test.ts
@@ -82,6 +82,8 @@ describe("render()", () => {
 
       export type CONTENT_TYPE = \\"myContentType\\"
 
+      export type IEntry = IMyContentType
+
       export type LOCALE_CODE = \\"en-US\\" | \\"pt-BR\\"
 
       export type CONTENTFUL_DEFAULT_LOCALE_CODE = \\"en-US\\"
@@ -152,6 +154,8 @@ describe("render()", () => {
 
       export type CONTENT_TYPE = \\"myContentType\\"
 
+      export type IEntry = IMyContentType
+
       export type LOCALE_CODE = \\"en-US\\" | \\"pt-BR\\"
 
       export type CONTENTFUL_DEFAULT_LOCALE_CODE = \\"en-US\\"
@@ -214,6 +218,8 @@ describe("render()", () => {
         }
 
         export type CONTENT_TYPE = \\"myContentType\\"
+
+        export type IEntry = IMyContentType
 
         export type LOCALE_CODE = \\"en-US\\" | \\"pt-BR\\"
 


### PR DESCRIPTION
I'm proposing adding an `IEntry` interface (open to discuss about naming 😄 ). This type would represent "an Entry coming from our Contentful instance."

In our case, we end up writing `Entry<any>` many times, especially in methods used for type checking:

```typescript
function isHero(entry: Entry<any>): entry is IHero {
  return entry.sys.contentType?.sys.id === 'hero'
}
```

This allows us to be more specific on the type:

```typescript
function isHero(entry: IEntry): entry is IHero {
  return entry.sys.contentType?.sys.id === 'hero'
}
```