### PR TITLE
Add support for CJS config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then, add the following to your `package.json`:
 
 Feel free to change the output path to whatever you like.
 
-Next, the codegen will expect you to have created a file called either `getContentfulEnvironment.js` or `getContentfulEnvironment.ts`
+Next, the codegen will expect you to have created a file called `getContentfulEnvironment.js`, `getContentfulEnvironment.cjs` or `getContentfulEnvironment.ts`
 in the root of your project directory, which should export a promise that resolves with your Contentful environment.
 
 The reason for this is that you can do whatever you like to set up your Contentful Management

--- a/src/loadEnvironment.ts
+++ b/src/loadEnvironment.ts
@@ -60,6 +60,8 @@ function determineEnvironmentPath() {
 
   if (fs.existsSync(`${pathWithoutExtension}.ts`)) {
     return `${pathWithoutExtension}.ts`
+  } else if (fs.existsSync(`${pathWithoutExtension}.cjs`)) {
+    return `${pathWithoutExtension}.cjs`
   }
 
   return `${pathWithoutExtension}.js`


### PR DESCRIPTION
This allows using this package on ESM environments, by declaring a `getContentfulEnvironment.cjs` config instead. Let me know what you think :smile: 

closes #116