### PR TITLE
Route CI dependency installs through Socket Firewall registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,13 @@ jobs:
             - v1-dependencies-{{arch}}-{{ checksum "package.json" }}
             - v1-dependencies-{{arch}}-
 
+      - run:
+          name: Verify Socket Firewall registry is active
+          command: |
+            REGISTRY=$(npm config get registry)
+            echo "npm registry: $REGISTRY"
+            echo "$REGISTRY" | grep -q socket-firewall-registry || { echo "FAIL: npm not routed through Socket Firewall"; exit 1; }
+
       - run: yarn install
 
       - save_cache:
@@ -40,4 +47,6 @@ workflows:
 
   test:
     jobs:
-      - test
+      - test:
+          context:
+            - socket-firewall

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Route all npm/yarn installs through the Socket Firewall registry
+registry=https://socket-firewall-registry.corporate.intercom.io/npm
+//socket-firewall-registry.corporate.intercom.io/npm/:_authToken=${SOCKET_NPM_TOKEN}
+always-auth=true


### PR DESCRIPTION
### Why?

Part of a CI supply-chain hardening effort: dependency installs should be scanned by Socket Firewall before they're fetched. This repo's CI ran `yarn install` directly from the public npm registry with no such scanning.

### How?

Adds an `.npmrc` pointing yarn at the Socket Firewall registry, with the token injected at runtime via the `socket-firewall` CircleCI context — no credential committed — plus a verify step that fails the build if installs aren't routed through Socket. All dependencies are public, so no scoped-registry exception is needed.

<sub>Generated with Claude Code</sub>