### PR TITLE
Harden staged-publish workflow: fix ancestry guard, serialize releases, bound runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,18 @@ on:
 permissions:
   contents: read              # workflow default (least privilege); only stage-publish also needs id-token, granted on that job
 
+concurrency:
+  group: publish-${{ github.workflow }}   # serialize all publish runs; never two staged releases racing for a dist-tag
+  cancel-in-progress: false               # queue, don't cancel: killing a half-done `npm stage publish` is the torn state we're avoiding
+
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-        with: { persist-credentials: false }
+        with:
+          persist-credentials: false
+          fetch-depth: 0                   # full history so origin/<default> ancestry is computable; checkout fetches authenticated before stripping creds
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'      # pin >= 22.14.0
@@ -35,13 +41,13 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          git fetch origin "$DEFAULT_BRANCH" --depth=1
           git merge-base --is-ancestor "$GITHUB_SHA" "origin/$DEFAULT_BRANCH" \
             || { echo "release $RELEASE_TAG not reachable from $DEFAULT_BRANCH — refusing"; exit 1; }
 
   stage-publish:
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 15         # bound a hung publish instead of running to the 6h default
     permissions:
       contents: read
       id-token: write           # OIDC trusted publishing: only this job mints the token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,8 @@ permissions:
   contents: read              # workflow default (least privilege); only stage-publish also needs id-token, granted on that job
 
 concurrency:
-  group: publish-${{ github.workflow }}   # serialize all publish runs; never two staged releases racing for a dist-tag
-  cancel-in-progress: false               # queue, don't cancel: killing a half-done `npm stage publish` is the torn state we're avoiding
+  group: publish-${{ github.workflow }}   # serialize publishes; no dist-tag races
+  cancel-in-progress: false               # queue, don't kill an in-flight publish
 
 jobs:
   verify:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
         with:
           persist-credentials: false
-          fetch-depth: 0                   # full history so origin/<default> ancestry is computable; checkout fetches authenticated before stripping creds
+          fetch-depth: 0                   # full history for the ancestry check below
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'      # pin >= 22.14.0
@@ -47,7 +47,7 @@ jobs:
   stage-publish:
     needs: verify
     runs-on: ubuntu-latest
-    timeout-minutes: 15         # bound a hung publish instead of running to the 6h default
+    timeout-minutes: 15         # cap a hung publish
     permissions:
       contents: read
       id-token: write           # OIDC trusted publishing: only this job mints the token


### PR DESCRIPTION
### Why?

Follow-up to the merged staged-publishing workflow, applying three fixes validated on the sibling packages.

### How?

- **Fix the ancestry guard.** Use `fetch-depth: 0` and drop the manual `git fetch`. The double-shallow checkout+fetch left the tag commit and the default-branch tip with no shared history, so `merge-base --is-ancestor` only passed when the tag was the branch tip — failing closed on legitimate releases.
- **Add `concurrency:`** so overlapping releases serialize instead of racing for a dist-tag.
- **Add `timeout-minutes: 15`** to the publish job.

<sub>Generated with Claude Code</sub>